### PR TITLE
ci: add Copilot automation + security workflows (14 workflows)

### DIFF
--- a/.github/workflows/auto-approve-workflows.yml
+++ b/.github/workflows/auto-approve-workflows.yml
@@ -1,0 +1,64 @@
+name: Auto-trigger Copilot Workflows
+
+on:
+  schedule:
+    - cron: "*/2 * * * *"
+  workflow_dispatch:
+
+jobs:
+  auto-trigger:
+    name: Trigger workflows for blocked Copilot PRs
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Trigger workflows via dispatch (bypasses approval)
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          echo "Checking for action_required workflow runs from Copilot..."
+
+          BLOCKED=$(gh api repos/${{ github.repository }}/actions/runs \
+            --jq '[.workflow_runs[] | select(.conclusion == "action_required") | select(.actor.login == "Copilot" or .actor.login == "copilot-swe-agent") | {id: .id, name: .name, branch: .head_branch, workflow_id: .workflow_id}]' \
+            2>/dev/null || echo "[]")
+
+          COUNT=$(echo "$BLOCKED" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No blocked Copilot workflow runs found."
+            exit 0
+          fi
+
+          echo "Found $COUNT blocked runs"
+          BRANCHES=$(echo "$BLOCKED" | jq -r '[.[].branch] | unique | .[]')
+
+          for BRANCH in $BRANCHES; do
+            echo "Triggering CI for branch: $BRANCH"
+
+            RUNNING=$(gh api repos/${{ github.repository }}/actions/runs \
+              --jq "[.workflow_runs[] | select(.head_branch == \"$BRANCH\") | select(.status == \"in_progress\" or .status == \"queued\") | select(.conclusion != \"action_required\")] | length" \
+              2>/dev/null || echo "0")
+
+            if [ "$RUNNING" -gt 0 ]; then
+              echo "  Already has $RUNNING running workflows, skipping"
+              continue
+            fi
+
+            RECENT=$(gh api repos/${{ github.repository }}/actions/runs \
+              --jq "[.workflow_runs[] | select(.head_branch == \"$BRANCH\") | select(.event == \"workflow_dispatch\") | select(.conclusion == \"success\" or .status == \"in_progress\" or .status == \"queued\")] | .[0:1] | length" \
+              2>/dev/null || echo "0")
+
+            if [ "$RECENT" -gt 0 ]; then
+              echo "  Recent dispatch run exists, skipping"
+              continue
+            fi
+
+            gh api -X POST repos/${{ github.repository }}/actions/workflows/copilot-branch-ci.yml/dispatches \
+              -f ref="$BRANCH" 2>&1 || echo "  Failed to trigger CI for $BRANCH"
+
+            gh api -X POST repos/${{ github.repository }}/actions/workflows/security-codeql.yml/dispatches \
+              -f ref="$BRANCH" 2>&1 || true
+            gh api -X POST repos/${{ github.repository }}/actions/workflows/security-gitleaks.yml/dispatches \
+              -f ref="$BRANCH" 2>&1 || true
+
+            echo "  Triggered workflows for $BRANCH"
+          done
+
+          echo "Done."

--- a/.github/workflows/automation-cleanup-pr-body.yml
+++ b/.github/workflows/automation-cleanup-pr-body.yml
@@ -1,0 +1,84 @@
+name: Automation - Clean PR Body
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  cleanup:
+    runs-on: [self-hosted, Linux]
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Cleanup PR Body
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            let body = pr.body || '';
+
+            if (body.length < 10) {
+              console.log('PR body is too short, skipping cleanup');
+              return;
+            }
+
+            let modified = false;
+
+            // Remove HTML comments
+            const withoutComments = body.replace(/<!--[\s\S]*?-->/g, '');
+            if (withoutComments !== body) {
+              body = withoutComments;
+              modified = true;
+            }
+
+            // Remove empty sections
+            const lines = body.split('\n');
+            const cleanedLines = [];
+            for (let i = 0; i < lines.length; i++) {
+              const line = lines[i];
+              const isHeader = line.match(/^#{1,6}\s+/);
+              if (isHeader) {
+                let hasContent = false;
+                for (let j = i + 1; j < lines.length; j++) {
+                  const nextLine = lines[j];
+                  if (nextLine.trim() === '') continue;
+                  if (nextLine.match(/^#{1,6}\s+/)) break;
+                  hasContent = true;
+                  break;
+                }
+                if (hasContent) {
+                  cleanedLines.push(line);
+                } else {
+                  modified = true;
+                }
+              } else {
+                cleanedLines.push(line);
+              }
+            }
+            body = cleanedLines.join('\n');
+
+            // Remove multiple consecutive empty lines
+            const withSingleNewlines = body.replace(/\n{3,}/g, '\n\n');
+            if (withSingleNewlines !== body) {
+              body = withSingleNewlines;
+              modified = true;
+            }
+
+            const trimmed = body.trim();
+            if (trimmed !== body) {
+              body = trimmed;
+              modified = true;
+            }
+
+            if (modified && body.length > 0) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                body: body
+              });
+              console.log('PR body cleaned up successfully');
+            } else {
+              console.log('No cleanup needed');
+            }

--- a/.github/workflows/automation-stale.yml
+++ b/.github/workflows/automation-stale.yml
@@ -1,0 +1,33 @@
+name: Automation - Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: [self-hosted, Linux]
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+            If this issue is still relevant, please comment or remove the stale label.
+          stale-issue-label: 'stale'
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          exempt-issue-labels: 'blocked,priority: high,pinned'
+          stale-pr-message: |
+            This PR has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+          stale-pr-label: 'stale'
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          exempt-pr-labels: 'blocked,priority: high'

--- a/.github/workflows/copilot-auto-assign.yml
+++ b/.github/workflows/copilot-auto-assign.yml
@@ -1,0 +1,187 @@
+name: Auto-assign Copilot to Priority Issues
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  assign-copilot:
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Check for active Copilot PRs
+        id: check-prs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const copilotPRs = prs.filter(pr =>
+              pr.user.login === 'copilot[bot]' ||
+              pr.user.login === 'Copilot' ||
+              pr.user.login === 'app/copilot-swe-agent' ||
+              pr.user.login.toLowerCase().includes('copilot')
+            );
+
+            console.log(`Found ${copilotPRs.length} active Copilot PRs`);
+
+            if (copilotPRs.length > 0) {
+              console.log('Copilot is busy, skipping assignment');
+              core.setOutput('busy', 'true');
+              return;
+            }
+
+            core.setOutput('busy', 'false');
+
+      - name: Find highest priority unassigned issue
+        id: find-issue
+        if: steps.check-prs.outputs.busy == 'false'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const labelPriority = {
+              'priority: critical': 0,
+              'priority:critical': 0,
+              'copilot-ready': 0.5,
+              'priority: high': 1,
+              'priority:high': 1,
+              'priority: medium': 2,
+              'priority:medium': 2,
+              'priority: low': 3,
+              'priority:low': 3
+            };
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const candidates = issues.filter(issue => {
+              if (issue.pull_request) return false;
+              if (issue.title.includes('EPIC')) return false;
+              const assignees = issue.assignees.map(a => a.login.toLowerCase());
+              if (assignees.some(a => a.includes('copilot'))) return false;
+              const labels = issue.labels.map(l => l.name.toLowerCase());
+              const hasCopilotLabel = labels.includes('copilot');
+              const hasPriorityLabel = labels.some(l => l.startsWith('priority:') || l.startsWith('priority: '));
+              if (!hasCopilotLabel && !(hasPriorityLabel && issue.assignees.length === 0)) {
+                return false;
+              }
+              const titleLower = issue.title.toLowerCase();
+              if (titleLower.includes('[blocked]') || titleLower.includes('[wip]')) return false;
+              return true;
+            });
+
+            if (candidates.length === 0) {
+              console.log('No eligible issues found for Copilot assignment');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            const scoredIssues = candidates.map(issue => {
+              let score = 1000;
+              for (const label of issue.labels) {
+                const labelName = label.name.toLowerCase();
+                if (labelPriority[labelName] !== undefined) {
+                  score = labelPriority[labelName] * 100;
+                  break;
+                }
+              }
+              score += issue.number / 100000;
+              return { issue, score };
+            });
+
+            scoredIssues.sort((a, b) => a.score - b.score);
+            const topIssue = scoredIssues[0].issue;
+            console.log(`Selected issue #${topIssue.number}: ${topIssue.title}`);
+
+            core.setOutput('found', 'true');
+            core.setOutput('issue_number', topIssue.number);
+            core.setOutput('issue_title', topIssue.title);
+
+      - name: Assign Copilot to issue (GraphQL)
+        if: steps.check-prs.outputs.busy == 'false' && steps.find-issue.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          ISSUE_NUMBER=${{ steps.find-issue.outputs.issue_number }}
+          echo "Assigning Copilot to issue #${ISSUE_NUMBER}"
+
+          COPILOT_BOT_ID=$(gh api graphql -f query='
+            query($owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) {
+                suggestedActors(first: 100, capabilities: CAN_BE_ASSIGNED) {
+                  nodes {
+                    ... on Bot {
+                      id
+                      login
+                    }
+                  }
+                }
+              }
+            }
+          ' -f owner="${{ github.repository_owner }}" -f name="${{ github.event.repository.name }}" \
+            --jq '.data.repository.suggestedActors.nodes[] | select(.login == "copilot-swe-agent") | .id')
+
+          if [ -z "$COPILOT_BOT_ID" ]; then
+            echo "::error::Copilot bot not found. Make sure Copilot is enabled and GH_PAT has correct scopes."
+            exit 1
+          fi
+
+          echo "Found Copilot bot with ID: $COPILOT_BOT_ID"
+
+          ISSUE_ID=$(gh api graphql -f query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                issue(number: $number) {
+                  id
+                }
+              }
+            }
+          ' -f owner="${{ github.repository_owner }}" -f name="${{ github.event.repository.name }}" -F number="$ISSUE_NUMBER" \
+            --jq '.data.repository.issue.id')
+
+          MUTATION_JSON=$(printf '{"query":"mutation { replaceActorsForAssignable(input: {assignableId: \\"%s\\", actorIds: [\\"%s\\"]}) { assignable { ... on Issue { assignees(first: 10) { nodes { login } } } } } }"}' "$ISSUE_ID" "$COPILOT_BOT_ID")
+          RESULT=$(echo "$MUTATION_JSON" | gh api graphql --input - --jq '.data.replaceActorsForAssignable.assignable.assignees.nodes[].login')
+
+          echo "Successfully assigned! New assignees: $RESULT"
+
+      - name: Mention Copilot on issue
+        if: steps.check-prs.outputs.busy == 'false' && steps.find-issue.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          ISSUE_NUMBER=${{ steps.find-issue.outputs.issue_number }}
+          gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "@copilot Please implement this issue. Create a fresh branch from current master and open a PR when ready. _Auto-triggered by CI (no active Copilot PRs detected)_"
+          echo "Mentioned Copilot on issue #${ISSUE_NUMBER}"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Copilot Auto-Assignment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check-prs.outputs.busy }}" == "true" ]; then
+            echo "⏳ Copilot is currently busy with an open PR" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.find-issue.outputs.found }}" == "true" ]; then
+            echo "✅ Assigned Copilot to issue #${{ steps.find-issue.outputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**${{ steps.find-issue.outputs.issue_title }}**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "📭 No unassigned issues found" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/copilot-auto-review-llm.yml
+++ b/.github/workflows/copilot-auto-review-llm.yml
@@ -1,0 +1,277 @@
+name: Copilot Auto-Review (LLM)
+
+on:
+  workflow_run:
+    workflows: ["Copilot Branch CI"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  auto-review:
+    name: LLM Auto-Review
+    runs-on: [self-hosted, Linux]
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Find PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR=$(gh api repos/${{ github.repository }}/pulls \
+            --jq ".[] | select(.head.ref == \"$BRANCH\") | .number" | head -1)
+
+          if [ -z "$PR" ]; then
+            echo "No PR found for branch $BRANCH"
+            echo "pr_number=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pr_number=$PR" >> $GITHUB_OUTPUT
+          echo "Found PR #$PR for branch $BRANCH"
+
+      - name: Check for Copilot Reviewer feedback
+        id: review
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+
+          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last')
+
+          if [ -z "$REVIEW" ] || [ "$REVIEW" == "null" ]; then
+            echo "No Copilot review found"
+            echo "has_review=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          REVIEW_BODY=$(echo "$REVIEW" | jq -r '.body // ""')
+          echo "has_review=true" >> $GITHUB_OUTPUT
+          echo "review_body<<EOF" >> $GITHUB_OUTPUT
+          echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          COMMENT_COUNT=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+          echo "comment_count=$COMMENT_COUNT" >> $GITHUB_OUTPUT
+
+          REVIEW_ID=$(echo "$REVIEW" | jq -r '.id')
+          echo "review_id=$REVIEW_ID" >> $GITHUB_OUTPUT
+
+      - name: Get review comments
+        id: comments
+        if: steps.review.outputs.has_review == 'true' && steps.review.outputs.review_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          REVIEW_ID="${{ steps.review.outputs.review_id }}"
+
+          COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews/$REVIEW_ID/comments" \
+            --jq '[.[] | {path: .path, body: .body}]')
+
+          echo "comments_json<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENTS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Decide with Local LLM
+        id: llm_decision
+        if: steps.review.outputs.has_review == 'true'
+        env:
+          REVIEW_BODY: ${{ steps.review.outputs.review_body }}
+          COMMENT_COUNT: ${{ steps.review.outputs.comment_count }}
+          OLLAMA_HOST: "http://localhost:11434"
+          OLLAMA_USER: "copilot-review"
+          OLLAMA_MODEL: "qwen3-coder-30b-q4km-32k:latest"
+        run: |
+          set +e
+
+          PROMPT=$'You are a PR review triage assistant.\n\n'
+          PROMPT+=$'Inputs:\n- Copilot Reviewer review body (text)\n- Copilot Reviewer inline comment count (integer)\n\n'
+          PROMPT+=$'Task:\nDecide whether this PR should be marked as ready for human review or needs fixes.\n\n'
+          PROMPT+=$'Return EXACTLY one line of JSON with this schema:\n{"decision":"approve"|"request_fixes","reason":"short reason"}\n\n'
+          PROMPT+=$'Rules:\n- If the review indicates 0 issues / no new comments, decision=approve.\n- If there are any issues or ambiguity, decision=request_fixes.\n- Keep reason <= 80 characters.\n\n'
+          PROMPT+=$'Review body:\n'
+          PROMPT+="$REVIEW_BODY"
+          PROMPT+=$'\n\nInline comment count:\n'
+          PROMPT+="$COMMENT_COUNT"
+
+          RESPONSE=$(curl -s -u "${OLLAMA_USER}:" "${OLLAMA_HOST}/api/generate" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg m \"$OLLAMA_MODEL\" --arg p \"$PROMPT\" '{model:$m,prompt:$p,stream:false,options:{num_predict:200,temperature:0.1}}')")
+
+          TEXT=$(echo "$RESPONSE" | jq -r '.response // empty' | tr -d '\r')
+          JSON_LINE=$(echo "$TEXT" | grep -oP '\{.*\}' | head -1)
+
+          if [ -n "$JSON_LINE" ]; then
+            echo "$JSON_LINE" | jq -e . >/dev/null 2>&1
+            if [ $? -eq 0 ]; then
+              DECISION=$(echo "$JSON_LINE" | jq -r '.decision // empty')
+              REASON=$(echo "$JSON_LINE" | jq -r '.reason // empty')
+              if [ -n "$DECISION" ] && [ -n "$REASON" ]; then
+                echo "used_local_llm=true" >> $GITHUB_OUTPUT
+                echo "decision=$DECISION" >> $GITHUB_OUTPUT
+                echo "reason=$REASON" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+          fi
+
+          echo "used_local_llm=false" >> $GITHUB_OUTPUT
+          exit 0
+
+      - name: Analyze and decide
+        id: decision
+        if: steps.review.outputs.has_review == 'true'
+        env:
+          REVIEW_BODY: ${{ steps.review.outputs.review_body }}
+          LLM_DECISION: ${{ steps.llm_decision.outputs.decision }}
+          LLM_REASON: ${{ steps.llm_decision.outputs.reason }}
+        run: |
+          if echo "$REVIEW_BODY" | grep -qi "wasn't able to review any files"; then
+            echo "decision=skip" >> $GITHUB_OUTPUT
+            echo "reason=Copilot Reviewer couldn't review any files" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ -n "$LLM_DECISION" ] && [ -n "$LLM_REASON" ]; then
+            echo "decision=$LLM_DECISION" >> $GITHUB_OUTPUT
+            echo "reason=$LLM_REASON" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if echo "$REVIEW_BODY" | grep -qi "generated no new comments\|generated 0 comments\|no issues"; then
+            echo "decision=approve" >> $GITHUB_OUTPUT
+            echo "reason=Copilot Reviewer found no issues" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          COMMENT_NUM=$(echo "$REVIEW_BODY" | grep -oP 'generated \K\d+(?= comment)' || echo "0")
+          if [ "$COMMENT_NUM" -eq 0 ]; then
+            echo "decision=approve" >> $GITHUB_OUTPUT
+            echo "reason=No review comments from Copilot Reviewer" >> $GITHUB_OUTPUT
+          else
+            echo "decision=request_fixes" >> $GITHUB_OUTPUT
+            echo "reason=Copilot Reviewer has $COMMENT_NUM comments to address" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate fix request with LLM
+        id: llm
+        if: steps.decision.outputs.decision == 'request_fixes' && steps.review.outputs.comment_count != '0'
+        env:
+          COMMENTS_JSON: ${{ steps.comments.outputs.comments_json }}
+          OLLAMA_HOST: "http://localhost:11434"
+          OLLAMA_USER: "copilot-review"
+        run: |
+          if [ -z "$COMMENTS_JSON" ] || [ "$COMMENTS_JSON" = "[]" ]; then
+            echo "No inline review comments to convert; skipping"
+            echo "fix_message=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          ALLOWED_PATHS=$(echo "$COMMENTS_JSON" | jq -r '.[].path' | sort -u | tr '\n' ' ')
+
+          PROMPT="You are converting GitHub Copilot Reviewer feedback into actionable fix requests.
+
+          Create a well-structured comment for @copilot following this format:
+
+          @copilot Please address the following review feedback:
+
+          ## 1. [filename] - Brief title
+          **Problem:** What is wrong
+          **Fix:** Specific change needed
+          **Acceptance:** How to verify
+
+          Rules:
+          - Start with @copilot
+          - Be specific about files and changes
+          - Do not skip any review comments
+          - Do NOT invent file paths. Only reference paths from this allowed list: $ALLOWED_PATHS
+
+          Review comments to convert:
+          $COMMENTS_JSON"
+
+          RESPONSE=$(curl -s -u "${OLLAMA_USER}:" "${OLLAMA_HOST}/api/generate" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg p \"$PROMPT\" '{model:\"qwen3-coder-30b-q4km-32k:latest\",prompt:$p,stream:false,options:{num_predict:1500,temperature:0.2}}')")
+
+          FIX_MSG=$(echo "$RESPONSE" | jq -r '.response // empty')
+
+          if [ -z "$FIX_MSG" ]; then
+            echo "LLM response empty"
+            echo "fix_message=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "fix_message<<EOF" >> $GITHUB_OUTPUT
+          echo "$FIX_MSG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post note (Copilot Reviewer couldn't review)
+        if: steps.decision.outputs.decision == 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          MARKER="<!-- mark1:auto-review:copilot-unable -->"
+
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Already posted unable-to-review note, skipping"
+            exit 0
+          fi
+
+          gh pr comment "$PR_NUMBER" --body "⚠️ **Auto Review**: Copilot Reviewer couldn't review any files.\n\nPlease re-request review or push a small change.\n\n$MARKER"
+
+      - name: Post fix request to Copilot
+        if: steps.llm.outputs.fix_message != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+
+          LAST_FIX_REQUEST=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | startswith("@copilot Please address"))] | last | .created_at // empty')
+
+          if [ -n "$LAST_FIX_REQUEST" ]; then
+            AGE=$(( $(date +%s) - $(date -d "$LAST_FIX_REQUEST" +%s) ))
+            if [ "$AGE" -lt 3600 ]; then
+              echo "Already posted fix request within last hour, skipping"
+              exit 0
+            fi
+          fi
+
+          echo "Posting fix request to PR #$PR_NUMBER"
+          echo "${{ steps.llm.outputs.fix_message }}" > fix_request.md
+          gh pr comment "$PR_NUMBER" -F fix_request.md
+
+      - name: Record approve decision
+        if: steps.decision.outputs.decision == 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          REASON="${{ steps.decision.outputs.reason }}"
+          USED_LOCAL_LLM="${{ steps.llm_decision.outputs.used_local_llm }}"
+
+          echo "Skipping auto-approve - human review required for Copilot PRs"
+
+          if [ "$USED_LOCAL_LLM" = "true" ]; then
+            REVIEWED_BY="Local LLM (Guardian: qwen3-coder-30b)"
+          else
+            REVIEWED_BY="Heuristics (local LLM unavailable)"
+          fi
+
+          echo "### Auto Review" >> $GITHUB_STEP_SUMMARY
+          echo "- PR: #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+          echo "- Decision: approve" >> $GITHUB_STEP_SUMMARY
+          echo "- Reason: $REASON" >> $GITHUB_STEP_SUMMARY
+          echo "- Reviewed by: $REVIEWED_BY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/copilot-autofix.yml
+++ b/.github/workflows/copilot-autofix.yml
@@ -1,0 +1,48 @@
+name: Copilot Branch Autofix
+
+on:
+  workflow_run:
+    workflows: ["Copilot Branch CI"]
+    types: [completed]
+    branches:
+      - 'copilot/**'
+
+permissions:
+  contents: write
+
+jobs:
+  autofix:
+    name: Auto-fix style issues
+    runs-on: [self-hosted, Linux]
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Fix style issues
+        run: |
+          pip install ruff -q
+          ruff check --fix . || true
+          ruff format . || true
+
+      - name: Commit and push fixes
+        run: |
+          if git diff --quiet; then
+            echo "No style fixes needed - failure was from something else"
+            exit 1
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "style: auto-fix code style issues"
+            git push
+            echo "✅ Style fixes pushed - CI will re-run automatically"
+          fi

--- a/.github/workflows/copilot-branch-ci.yml
+++ b/.github/workflows/copilot-branch-ci.yml
@@ -1,0 +1,187 @@
+name: Copilot Branch CI
+
+# Lightweight CI for Copilot branches. Runs lint + syntax checks only.
+# The full Mycodo CI (main.yml) runs on PRs to master.
+
+on:
+  push:
+    branches:
+      - 'copilot/**'
+  workflow_dispatch:
+
+concurrency:
+  group: copilot-branch-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  statuses: write
+  checks: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  ci:
+    name: Run CI checks
+    runs-on: [self-hosted, Linux]
+    outputs:
+      ci_passed: ${{ steps.result.outputs.passed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install lint tools
+        run: pip install ruff -q
+
+      - name: Ruff lint
+        id: ruff
+        run: |
+          set -o pipefail
+          ruff check . --output-format=github 2>&1 | tee ruff.log
+        continue-on-error: true
+
+      - name: Ruff format check
+        id: format
+        run: |
+          set -o pipefail
+          ruff format --check . 2>&1 | tee format.log
+        continue-on-error: true
+
+      - name: Python syntax check
+        id: syntax
+        run: |
+          set -o pipefail
+          find mycodo/ -name "*.py" -exec python -m py_compile {} + 2>&1 | tee syntax.log
+        continue-on-error: true
+
+      - name: Determine result
+        id: result
+        run: |
+          if [ "${{ steps.ruff.outcome }}" == "success" ] && \
+             [ "${{ steps.format.outcome }}" == "success" ] && \
+             [ "${{ steps.syntax.outcome }}" == "success" ]; then
+            echo "passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "passed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post status check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA="${{ github.sha }}"
+
+          if [ "${{ steps.result.outputs.passed }}" == "true" ]; then
+            STATE="success"
+            DESC="All CI checks passed"
+          else
+            STATE="failure"
+            DESC="Some checks failed"
+          fi
+
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            -f state="$STATE" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f description="$DESC" \
+            -f context="Copilot CI"
+
+      - name: Post PR review comment (on failure)
+        if: steps.result.outputs.passed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          REPO="${{ github.repository }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          PR_NUMBER="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch $BRANCH; skipping PR review comment."
+            exit 0
+          fi
+
+          MARKER="<!-- copilot-branch-ci:sha=$SHA -->"
+
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=20" --jq '.[].body // ""' | grep -Fq "$MARKER"; then
+            echo "Review comment already posted for $SHA on PR #$PR_NUMBER; skipping."
+            exit 0
+          fi
+
+          summarize_outcome() {
+            local name="$1"
+            local outcome="$2"
+            if [ "$outcome" = "success" ]; then
+              echo "- $name: ✅ success"
+            else
+              echo "- $name: ❌ $outcome"
+            fi
+          }
+
+          BODY_FILE="ci-review-body.md"
+          {
+            echo "$MARKER"
+            echo "### CI failed for $BRANCH"
+            echo
+            echo "Run: $RUN_URL"
+            echo "SHA: $SHA"
+            echo
+            echo "**Summary**"
+            summarize_outcome "ruff lint" "${{ steps.ruff.outcome }}"
+            summarize_outcome "ruff format" "${{ steps.format.outcome }}"
+            summarize_outcome "syntax check" "${{ steps.syntax.outcome }}"
+            echo
+            echo "**Details (logs)**"
+            echo
+            for f in ruff.log format.log syntax.log; do
+              if [ -f "$f" ]; then
+                echo "<details><summary>$f</summary>"
+                echo
+                echo "\`\`\`"
+                tail -n 200 "$f" || true
+                echo "\`\`\`"
+                echo
+                echo "</details>"
+                echo
+              fi
+            done
+          } > "$BODY_FILE"
+
+          gh pr review --repo "$REPO" "$PR_NUMBER" --comment --body-file "$BODY_FILE"
+
+          FIX_MARKER="<!-- copilot-ci-fix:sha=$SHA -->"
+          COMMENTS_BODIES="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" --jq '.[].body // ""')"
+
+          if echo "$COMMENTS_BODIES" | grep -Fq "$FIX_MARKER"; then
+            echo "Fix request already posted for $SHA on PR #$PR_NUMBER; skipping."
+            exit 0
+          fi
+
+          FIX_COUNT="$(echo "$COMMENTS_BODIES" | grep -c '<!-- copilot-ci-fix:sha=' || true)"
+          if [ "${FIX_COUNT:-0}" -ge 3 ]; then
+            echo "Fix request cycle limit reached ($FIX_COUNT); skipping @copilot trigger."
+            exit 0
+          fi
+
+          FIX_BODY_FILE="ci-fix-request.md"
+          {
+            echo "@copilot please fix the CI failures reported in the CI review comment above."
+            echo
+            echo "Run: $RUN_URL"
+            echo "SHA: $SHA"
+            echo
+            echo "$FIX_MARKER"
+          } > "$FIX_BODY_FILE"
+
+          gh pr comment --repo "$REPO" "$PR_NUMBER" --body-file "$FIX_BODY_FILE"
+
+      - name: Fail workflow if checks failed
+        if: steps.result.outputs.passed != 'true'
+        run: exit 1

--- a/.github/workflows/copilot-ci-feedback.yml
+++ b/.github/workflows/copilot-ci-feedback.yml
@@ -1,0 +1,155 @@
+name: Copilot CI Feedback
+
+on:
+  workflow_run:
+    workflows: ["Mycodo"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  notify-copilot:
+    name: Notify Copilot of CI failures
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${HEAD_SHA:0:7}"
+
+          echo "head_branch=$HEAD_BRANCH" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls \
+            --jq ".[] | select(.head.ref == \"$HEAD_BRANCH\" and .state == \"open\") | {number, author: .user.login}" \
+            | head -1)
+
+          if [ -z "$PR_DATA" ]; then
+            echo "No open PR found for branch $HEAD_BRANCH"
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
+
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "author=$PR_AUTHOR" >> $GITHUB_OUTPUT
+          echo "found=true" >> $GITHUB_OUTPUT
+
+          PR_AUTHOR_LOWER=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+          if [[ "$PR_AUTHOR_LOWER" == *"copilot"* ]] || [[ "$HEAD_BRANCH" == copilot/* ]]; then
+            echo "is_copilot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_copilot=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check loop protection
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.is_copilot == 'true'
+        id: loop_check
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          SHORT_SHA="${{ steps.pr.outputs.short_sha }}"
+
+          COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments --jq '.')
+
+          TWO_HOURS_AGO=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          RECENT_FIX_REQUESTS=$(echo "$COMMENTS" | jq --arg since "$TWO_HOURS_AGO" '
+            [.[] | select(
+              (.body | contains("@copilot")) and
+              (.body | ascii_downcase | contains("fix") or contains("failed")) and
+              (.created_at > $since)
+            )] | length')
+
+          echo "recent_requests=$RECENT_FIX_REQUESTS" >> $GITHUB_OUTPUT
+
+          ALREADY_REQUESTED=$(echo "$COMMENTS" | jq --arg sha "$SHORT_SHA" '
+            [.[] | select(.body | contains($sha))] | length')
+
+          if [ "$ALREADY_REQUESTED" -gt 0 ]; then
+            echo "Already requested fix for commit $SHORT_SHA"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=sha_duplicate" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          MAX_REQUESTS=3
+          if [ "$RECENT_FIX_REQUESTS" -ge "$MAX_REQUESTS" ]; then
+            echo "Loop protection: $RECENT_FIX_REQUESTS requests in last 2 hours"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=loop_protection" >> $GITHUB_OUTPUT
+            echo "request_count=$RECENT_FIX_REQUESTS" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+          NEXT_REQUEST=$((RECENT_FIX_REQUESTS + 1))
+          echo "request_num=$NEXT_REQUEST" >> $GITHUB_OUTPUT
+
+      - name: Get failed jobs
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.is_copilot == 'true' && steps.loop_check.outputs.skip != 'true'
+        id: failures
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          RUN_ID="${{ github.event.workflow_run.id }}"
+
+          FAILED_JOBS=$(gh api repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+
+          echo "jobs=$FAILED_JOBS" >> $GITHUB_OUTPUT
+          echo "url=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
+
+      - name: Notify Copilot to fix
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.is_copilot == 'true' && steps.loop_check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          SHORT_SHA="${{ steps.pr.outputs.short_sha }}"
+          FAILED_JOBS="${{ steps.failures.outputs.jobs }}"
+          RUN_URL="${{ steps.failures.outputs.url }}"
+          REQUEST_NUM="${{ steps.loop_check.outputs.request_num }}"
+
+          cat <<EOF > /tmp/comment.md
+          @copilot CI failed on commit \`${SHORT_SHA}\`. Please fix the following issues and push again:
+
+          **Failed checks:** ${FAILED_JOBS}
+
+          [View failed run](${RUN_URL})
+
+          _Auto-fix request ${REQUEST_NUM}/3_
+          EOF
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/comment.md
+          echo "Requested Copilot to fix CI failures on PR #$PR_NUMBER"
+
+      - name: Alert on loop protection triggered
+        if: steps.loop_check.outputs.reason == 'loop_protection'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          REQUEST_COUNT="${{ steps.loop_check.outputs.request_count }}"
+
+          cat <<EOF > /tmp/alert.md
+          ⚠️ **Auto-fix limit reached**
+
+          CI has failed ${REQUEST_COUNT}+ times in the last 2 hours. Manual intervention may be required.
+
+          cc @m0nk111
+          EOF
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/alert.md

--- a/.github/workflows/copilot-ready-pr.yml
+++ b/.github/workflows/copilot-ready-pr.yml
@@ -1,0 +1,91 @@
+name: Mark Copilot PRs Ready
+
+on:
+  workflow_run:
+    workflows: ["Mycodo"]
+    types:
+      - completed
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+jobs:
+  mark-ready:
+    name: Mark Copilot PR as ready for review
+    runs-on: [self-hosted, Linux]
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'copilot/')
+    steps:
+      - name: Mark PR ready for review
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          REPO="${{ github.repository }}"
+          MIN_AGE_SECONDS=3600
+
+          echo "Looking for draft PR on branch: $BRANCH"
+
+          PR_NUMBER=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number,isDraft --jq '.[] | select(.isDraft == true) | .number')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No draft PR found for branch $BRANCH"
+            exit 0
+          fi
+
+          CREATED_AT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json createdAt --jq '.createdAt')
+          NOW=$(date +%s)
+          CREATED_TS=$(date -d "$CREATED_AT" +%s)
+          AGE=$(( NOW - CREATED_TS ))
+          if [ "$AGE" -lt "$MIN_AGE_SECONDS" ]; then
+            echo "PR #$PR_NUMBER is too new ($AGE s < $MIN_AGE_SECONDS s). Skipping."
+            exit 0
+          fi
+
+          echo "Found draft PR #$PR_NUMBER, marking as ready for review..."
+          gh pr ready "$PR_NUMBER" --repo "$REPO"
+          echo "✅ PR #$PR_NUMBER is now ready for review"
+
+  scan-ready:
+    name: Scan Copilot draft PRs (>=1h)
+    runs-on: [self-hosted, Linux]
+    if: github.event_name != 'workflow_run'
+    steps:
+      - name: Mark eligible draft PRs ready
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+
+          REPO="${{ github.repository }}"
+          MIN_AGE_SECONDS=3600
+          NOW=$(date +%s)
+
+          PRS=$(gh pr list --repo "$REPO" --state open --json number,isDraft,createdAt,headRefName \
+            --jq '[.[] | select(.isDraft == true) | select(.headRefName | startswith("copilot/"))]')
+
+          COUNT=$(echo "$PRS" | jq 'length')
+          echo "Found $COUNT open draft Copilot PR(s) to evaluate"
+
+          echo "$PRS" | jq -c '.[]' | while read -r pr; do
+            PR_NUMBER=$(echo "$pr" | jq -r '.number')
+            BRANCH=$(echo "$pr" | jq -r '.headRefName')
+            CREATED_AT=$(echo "$pr" | jq -r '.createdAt')
+
+            CREATED_TS=$(date -d "$CREATED_AT" +%s)
+            AGE=$(( NOW - CREATED_TS ))
+            if [ "$AGE" -lt "$MIN_AGE_SECONDS" ]; then
+              echo "PR #$PR_NUMBER too new ($AGE s), skip"
+              continue
+            fi
+
+            CONCLUSION=$(gh run list --repo "$REPO" --workflow "Mycodo" --branch "$BRANCH" --limit 1 --json conclusion --jq '.[0].conclusion // empty' || true)
+            if [ "$CONCLUSION" != "success" ]; then
+              echo "PR #$PR_NUMBER latest CI conclusion is '$CONCLUSION', skip"
+              continue
+            fi
+
+            echo "Marking PR #$PR_NUMBER ready for review (age=${AGE}s, CI=success)"
+            gh pr ready "$PR_NUMBER" --repo "$REPO" || true
+          done

--- a/.github/workflows/copilot-rebase.yml
+++ b/.github/workflows/copilot-rebase.yml
@@ -1,0 +1,119 @@
+name: Copilot Rebase Helper
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to rebase (optional, rebases all Copilot PRs if empty)'
+        required: false
+        type: number
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase-copilot-prs:
+    runs-on: [self-hosted, Linux]
+
+    steps:
+      - name: Find Copilot PRs
+        id: find-prs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const inputPR = '${{ github.event.inputs.pr_number }}';
+
+            if (inputPR) {
+              core.setOutput('prs', JSON.stringify([parseInt(inputPR)]));
+              return;
+            }
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const copilotPRs = prs.filter(pr =>
+              pr.head.ref.startsWith('copilot/') ||
+              pr.user.login === 'copilot[bot]' ||
+              pr.user.login === 'Copilot'
+            );
+
+            const prNumbers = copilotPRs.map(pr => pr.number);
+            console.log(`Found ${prNumbers.length} Copilot PRs: ${prNumbers.join(', ')}`);
+            core.setOutput('prs', JSON.stringify(prNumbers));
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Rebase PRs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const prNumbers = JSON.parse('${{ steps.find-prs.outputs.prs }}');
+
+            for (const prNumber of prNumbers) {
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber
+                });
+
+                const branch = pr.head.ref;
+                console.log(`Rebasing PR #${prNumber} (${branch}) on master...`);
+
+                const { data: comparison } = await github.rest.repos.compareCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base: branch,
+                  head: 'master'
+                });
+
+                if (comparison.behind_by === 0) {
+                  console.log(`PR #${prNumber} is already up-to-date`);
+                  continue;
+                }
+
+                console.log(`PR #${prNumber} is ${comparison.behind_by} commits behind master`);
+
+                try {
+                  await github.rest.pulls.updateBranch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber
+                  });
+                  console.log(`Successfully updated PR #${prNumber}`);
+                } catch (mergeError) {
+                  console.log(`Could not auto-update PR #${prNumber}: ${mergeError.message}`);
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `⚠️ This PR is behind master and couldn't be automatically updated. Please rebase manually:\n\n\`\`\`bash\ngit fetch origin\ngit rebase origin/master\ngit push --force-with-lease\n\`\`\`\n\n_Auto-comment by rebase helper workflow_`
+                  });
+                }
+              } catch (error) {
+                console.error(`Error processing PR #${prNumber}:`, error.message);
+              }
+            }
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Copilot Rebase Helper Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Processed PRs: ${{ steps.find-prs.outputs.prs }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/copilot-request-review.yml
+++ b/.github/workflows/copilot-request-review.yml
@@ -1,0 +1,84 @@
+name: Copilot Request Review
+
+on:
+  workflow_run:
+    workflows: ["Copilot Branch CI"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  request-review:
+    name: Request Copilot Review
+    runs-on: [self-hosted, Linux]
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Find PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR=$(gh api repos/${{ github.repository }}/pulls \
+            --jq ".[] | select(.head.ref == \"$BRANCH\") | .number" | head -1)
+
+          if [ -z "$PR" ]; then
+            echo "No PR found for branch $BRANCH"
+            echo "pr_number=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pr_number=$PR" >> $GITHUB_OUTPUT
+
+      - name: Check if Copilot finished work
+        id: check
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+
+          FINISHED=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | test("Copilot finished work on behalf of"))] | length')
+
+          if [ "$FINISHED" -eq 0 ]; then
+            echo "Copilot not finished yet"
+            echo "copilot_finished=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "copilot_finished=true" >> $GITHUB_OUTPUT
+
+          EXISTING_REVIEW=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+
+          echo "existing_reviews=$EXISTING_REVIEW" >> $GITHUB_OUTPUT
+
+      - name: Request Copilot review
+        if: steps.check.outputs.copilot_finished == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          EXISTING="${{ steps.check.outputs.existing_reviews }}"
+
+          if [ "$EXISTING" -eq 0 ]; then
+            echo "Requesting initial Copilot review for PR #$PR_NUMBER"
+            gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+              -X POST \
+              -f team_reviewers[]="copilot-pull-request-reviewer" 2>/dev/null || \
+            gh pr edit "$PR_NUMBER" --add-reviewer "@copilot" 2>/dev/null || \
+            echo "Could not add Copilot as reviewer via standard methods"
+          else
+            echo "Copilot already reviewed, requesting re-review for PR #$PR_NUMBER"
+            REVIEW_ID=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .id')
+
+            if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
+              gh pr comment "$PR_NUMBER" --body "🔄 @copilot Please re-review this PR - new changes have been pushed."
+            fi
+          fi

--- a/.github/workflows/copilot-review-feedback.yml
+++ b/.github/workflows/copilot-review-feedback.yml
@@ -1,0 +1,145 @@
+name: Copilot Review Feedback
+
+on:
+  workflow_run:
+    workflows: ["Mycodo"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to check'
+        required: true
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  forward-review-to-agent:
+    runs-on: [self-hosted, Linux]
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Get PR info
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          else
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/pulls --jq '.[0].number // empty')
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found"
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "has_pr=true" >> $GITHUB_OUTPUT
+
+          PR_AUTHOR=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.user.login')
+          PR_AUTHOR_LOWER=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+          HEAD_REF=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.head.ref')
+          echo "author=$PR_AUTHOR" >> $GITHUB_OUTPUT
+          echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+
+          if [[ "$PR_AUTHOR_LOWER" == *"copilot"* ]] || [[ "$HEAD_REF" == copilot/* ]]; then
+            echo "is_copilot_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_copilot_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for unresolved review comments
+        if: steps.pr-info.outputs.has_pr == 'true' && steps.pr-info.outputs.is_copilot_pr == 'true'
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
+          MARKER="<!-- mark1:review-feedback-summary:v2 -->"
+
+          COPILOT_ADDRESSED_AT=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+            --jq '[.[] | select(.user.login | test("copilot"; "i")) | select(.body | test("addressed|no further action|complete"; "i"))] | last | .created_at // empty')
+
+          if [ -n "$COPILOT_ADDRESSED_AT" ]; then
+            COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+              --jq --arg since "$COPILOT_ADDRESSED_AT" '[.[] | select(.user.login | test("copilot"; "i")) | select(.created_at > $since) | {path: .path, line: .line, body: .body, created_at: .created_at}]')
+          else
+            COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments \
+              --jq '[.[] | select(.user.login | test("copilot"; "i")) | {path: .path, line: .line, body: .body, created_at: .created_at}]')
+          fi
+
+          COMMENT_COUNT=$(echo "$COMMENTS" | jq 'length')
+          echo "Found $COMMENT_COUNT new review comments"
+
+          LAST_REVIEW_COMMENT_AT=$(echo "$COMMENTS" | jq -r 'map(.created_at) | max // empty')
+          echo "last_review_comment_at=$LAST_REVIEW_COMMENT_AT" >> $GITHUB_OUTPUT
+
+          if [ "$COMMENT_COUNT" -gt 0 ] && [ -n "$LAST_REVIEW_COMMENT_AT" ]; then
+            LAST_SUMMARY=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+              --jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | last // empty')
+            if [ -n "$LAST_SUMMARY" ] && [ "$LAST_SUMMARY" != "null" ]; then
+              LAST_SUMMARY_AT=$(echo "$LAST_SUMMARY" | jq -r '.created_at // empty')
+              if [ -n "$LAST_SUMMARY_AT" ] && [[ "$LAST_SUMMARY_AT" > "$LAST_REVIEW_COMMENT_AT" ]]; then
+                echo "Already posted summary after latest review comment"
+                echo "should_notify=false" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+          fi
+
+          if [ "$COMMENT_COUNT" -gt 0 ]; then
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+            echo "count=$COMMENT_COUNT" >> $GITHUB_OUTPUT
+            FORMATTED=$(echo "$COMMENTS" | jq -r '.[] | "- \(.path):\(.line) - \(.body | split("\n")[0])"')
+            echo "formatted<<EOF" >> $GITHUB_OUTPUT
+            echo "$FORMATTED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "should_notify=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post review suggestions summary
+        if: steps.check-comments.outputs.should_notify == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
+          MARKER="<!-- mark1:review-feedback-summary:v2 -->"
+          COUNT="${{ steps.check-comments.outputs.count }}"
+          FORMATTED="${{ steps.check-comments.outputs.formatted }}"
+
+          cat <<'COMMENT_EOF' > /tmp/comment.md
+          🧾 **Copilot Reviewer suggestions detected** (summary only; no auto-trigger)
+
+          If you want the coding agent to implement these, add a new comment starting with:
+          `@copilot please implement the Copilot Reviewer suggestions`
+
+          <!-- mark1:review-feedback-summary:v2 -->
+          COMMENT_EOF
+
+          {
+            echo "";
+            echo "Count: $COUNT";
+            echo "";
+            echo "$FORMATTED";
+          } >> /tmp/comment.md
+
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file /tmp/comment.md
+
+      - name: Summary
+        run: |
+          echo "### Copilot Review Feedback" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.pr-info.outputs.has_pr }}" != "true" ]; then
+            echo "📭 No PR found for this commit" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.pr-info.outputs.is_copilot_pr }}" != "true" ]; then
+            echo "⏭️ PR #${{ steps.pr-info.outputs.number }} is not a Copilot PR (author: ${{ steps.pr-info.outputs.author }})" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.check-comments.outputs.should_notify }}" == "true" ]; then
+            echo "✅ Posted suggestions summary on PR #${{ steps.pr-info.outputs.number }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✨ No new suggestions on PR #${{ steps.pr-info.outputs.number }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -1,0 +1,41 @@
+name: Security - CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: [self-hosted, Linux]
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/security-gitleaks.yml
+++ b/.github/workflows/security-gitleaks.yml
@@ -1,0 +1,28 @@
+name: Security - Secret Scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Run Gitleaks (full scan)
+        run: gitleaks detect --source . --log-opts="--all" --verbose --exit-code 1


### PR DESCRIPTION
## Copilot Automation + Security Workflows

Adapted from `m0nklabs/cryptotrader` workflow suite for the Mycodo fork.

### What's included (14 workflows)

#### Copilot SWE Agent Automation (10)
| Workflow | Purpose |
|---|---|
| `auto-approve-workflows` | Bypass first-time contributor approval for Copilot PRs (runs every 2 min) |
| `copilot-auto-assign` | Auto-assign Copilot to highest priority open issue (runs every 5 min) |
| `copilot-branch-ci` | Lightweight lint CI for `copilot/**` branches (ruff + syntax check) |
| `copilot-autofix` | Auto-fix style issues when branch CI fails |
| `copilot-ci-feedback` | Notify Copilot of main CI failures with fix requests (loop protection: 3 max) |
| `copilot-ready-pr` | Mark draft PRs ready for review after CI passes (1h cooldown) |
| `copilot-rebase` | Keep Copilot branches up-to-date with master (manual dispatch) |
| `copilot-request-review` | Request Copilot Reviewer after agent finishes work |
| `copilot-auto-review-llm` | LLM-powered triage of Copilot Reviewer feedback via Guardian |
| `copilot-review-feedback` | Forward review suggestions summary to PR comments |

#### General Automation (2)
| Workflow | Purpose |
|---|---|
| `automation-cleanup-pr-body` | Clean HTML comments and empty sections from PR bodies |
| `automation-stale` | Mark/close stale issues (60d) and PRs (30d) |

#### Security (2)
| Workflow | Purpose |
|---|---|
| `security-codeql` | Python CodeQL analysis (weekly + on push/PR to master) |
| `security-gitleaks` | Secret scanning with Gitleaks (weekly + on push/PR to master) |

### What's NOT included (and why)
- `ci.yml` — `main.yml` already handles full Mycodo CI
- `automation-release.yml` — fork doesn't do releases
- `automation-label-issues.yml` — would need full label remap for Mycodo domain
- `custom-agent.yml` — requires `scripts/custom_agent.py` which doesn't exist yet

### Adaptations from cryptotrader
- Runner: `[self-hosted, Linux]` (no `org` label since this is a personal repo)
- Python version: 3.11 (Mycodo's version, not 3.12)
- Workflow triggers: `"CI"` → `"Mycodo"` (matches `main.yml` name)
- Removed `run-header` composite action references (doesn't exist in this repo)
- Removed database setup (no PostgreSQL needed)
- Removed EPIC priority map (no EPICs on this fork)
- Removed exchange-specific secrets (`BITFINEX_*`, `OPENROUTER_*`)
- Simplified Copilot Branch CI to lightweight lint only (full CI is too heavy for rapid iteration)
- CodeQL: Python only (no JavaScript)
- Alert cc: `@m0nk111` (not `@m0nk1111`)

### Required Secrets
| Secret | Purpose |
|---|---|
| `GH_PAT` | Personal Access Token with repo, workflow, read:org scopes |

### Required Setup
1. **Register self-hosted runner** for `m0nk111/Mycodo` (Settings → Actions → Runners → New self-hosted runner)
   - Labels: `self-hosted`, `Linux`
   - Same machine as cryptotrader runner (`192.168.1.26`)
2. **Add `GH_PAT` secret** (Settings → Secrets → Actions → New repository secret)
3. **Enable Copilot SWE agent** if not already enabled

### Copilot Agent Loop (how it works)
```
Issue created → auto-assign picks it up → Copilot creates branch + PR
→ copilot-branch-ci runs lint → autofix if needed → request-review
→ auto-review-llm triages feedback → posts fix requests if needed
→ Copilot fixes → CI re-runs → ready-pr marks it ready → human review
```